### PR TITLE
[FEAT] : 탭바 터치 시 화면 상단 이동 기능 구현

### DIFF
--- a/FakeBithumbAssignment/FakeBithumbAssignment/Screens/DepositAndWithdrawal/DepositAndWithdrawalViewController.swift
+++ b/FakeBithumbAssignment/FakeBithumbAssignment/Screens/DepositAndWithdrawal/DepositAndWithdrawalViewController.swift
@@ -17,7 +17,7 @@ class DepositAndWithdrawalViewController: BaseViewController {
     }
     private let headerView: DepositAndWithWithdrawalTableHeaderView =
     DepositAndWithWithdrawalTableHeaderView()
-    private let tableView: UITableView = UITableView().then {
+    let tableView: UITableView = UITableView().then {
         $0.register(
             DepositAndWithdrawalTableViewCell.self,
             forCellReuseIdentifier: DepositAndWithdrawalTableViewCell.className
@@ -109,7 +109,7 @@ class DepositAndWithdrawalViewController: BaseViewController {
 
     private func setUpSearchClearButton() {
         if let searchTextField = self.searchBar.value(forKey: "searchField") as? UITextField,
-           let clearButton = searchTextField.value(forKey: "_clearButton")as? UIButton {
+           let clearButton = searchTextField.value(forKey: "_clearButton") as? UIButton {
             clearButton.addTarget(
                 self,
                 action: #selector(clearButtonClicked),

--- a/FakeBithumbAssignment/FakeBithumbAssignment/Screens/Main/MainTabBarViewController.swift
+++ b/FakeBithumbAssignment/FakeBithumbAssignment/Screens/Main/MainTabBarViewController.swift
@@ -9,6 +9,8 @@ import UIKit
 
 class MainTabBarViewController: UITabBarController {
 
+    private var selectedTap = 0
+
     override func viewDidLoad() {
         super.viewDidLoad()
         configureUI()
@@ -27,6 +29,14 @@ class MainTabBarViewController: UITabBarController {
         self.tabBar.layer.shadowColor = UIColor.black.cgColor
         self.tabBar.layer.shadowOpacity = 0.3
     }
+
+    private func scrollToTop(_ tableView: UITableView?, indexPath: IndexPath) {
+        tableView?.scrollToRow(
+            at: indexPath,
+            at: .top,
+            animated: true
+        )
+    }
 }
 
 // MARK: - UITabBarControllerDelegate
@@ -37,22 +47,23 @@ extension MainTabBarViewController: UITabBarControllerDelegate {
         didSelect viewController: UIViewController
     ) {
         let tabBarIndex = tabBarController.selectedIndex
+        let indexPath = IndexPath(row: 0, section: 0)
+        let navigationViewController = viewController as? UINavigationController
+
         if tabBarIndex == 0 {
-            let indexPath = IndexPath(row: 0, section: 0)
-            let navigationViewController = viewController as? UINavigationController
+            self.selectedTap = 0
             let mainViewController = navigationViewController?.viewControllers[0] as? MainViewController
+            self.scrollToTop(mainViewController?.totalCoinListView.totalCoinListTableView, indexPath: indexPath)
+            self.scrollToTop(mainViewController?.interestedCoinListView.interestedCoinListTableView, indexPath: indexPath)
+        }
 
-            mainViewController?.totalCoinListView.totalCoinListTableView.scrollToRow(
-                at: indexPath,
-                at: .top,
-                animated: true
-            )
+        else if tabBarIndex == 1 {
+            if self.selectedTap == 1 {
+                let depositAndWithdrawalViewController = navigationViewController?.viewControllers[0] as? DepositAndWithdrawalViewController
+                self.scrollToTop(depositAndWithdrawalViewController?.tableView, indexPath: indexPath)
+            }
 
-            mainViewController?.interestedCoinListView.interestedCoinListTableView.scrollToRow(
-                at: indexPath as IndexPath,
-                at: .top,
-                animated: true
-            )
+            self.selectedTap = 1
         }
     }
 }

--- a/FakeBithumbAssignment/FakeBithumbAssignment/Screens/Main/MainViewController.swift
+++ b/FakeBithumbAssignment/FakeBithumbAssignment/Screens/Main/MainViewController.swift
@@ -387,7 +387,7 @@ final class MainViewController: BaseViewController {
         if let searchTextField = self.headerView.searchController.searchBar.value(
             forKey: "searchField"
         ) as? UITextField,
-           let clearButton = searchTextField.value(forKey: "_clearButton")as? UIButton {
+           let clearButton = searchTextField.value(forKey: "_clearButton") as? UIButton {
             clearButton.addTarget(
                 self,
                 action: #selector(clearButtonClicked),


### PR DESCRIPTION
탭바 터치 시 테이블 뷰의 첫 번째 셀 위치로 이동

## 📌 관련 이슈
<!-- close할 이슈 번호(#000)를 적어주세요. (ex. closed #16) -->
closed #54 

## 📌 구현 및 변경 사항
<!-- 구현 및 변경한 내용과 그 이유를 적어주세요. -->
* 탭바 터치 시 화면 상단으로 이동할 수 있도록 구현하였습니다.
* 입출금 현황 페이지는 뷰가 나타나기 직전에 REST API를 통해 데이터를 불러오기 때문에 화면에 진입할 때 항상 최상단의 데이터가 보입니다.
* 통일성을 맞추기 위해 입출금 현황 -> 메인으로 진입할 경우 최상단의 데이터가 보이도록 하였습니다.
* 또한 각각의 뷰 모두 테이블 뷰를 밑으로 스크롤 한 후 현재 속해있는 탭을 터치하게 되면 최상단으로 스크롤할 수 있습니다.

앞서 언급했지만, 입출금 현황 페이지는 뷰가 나타나기 직전에 데이터를 불러와 테이블 뷰를 나타냅니다.
MainTabBarViewController의
```swift
func tabBarController(_ tabBarController: UITabBarController, didSelect viewController: UIViewController)
```
델리게이트 메소드는 탭바 터치 시 입출금 현황의 테이블 뷰 데이터가 나타나기 전에 작동하게 되어 앱 크래쉬가 나게됩니다. (테이블 뷰의 데이터가 없는데 최상단으로 올리라는 동작때문에)
그래서 인스턴스 프로퍼티로 selectedTap를 선언하여 현재 페이지의 탭바 인덱스를 저장하고, 메인 -> 입출금 의 이동이 아닌 입출금의 페이지에서 탭바를 눌렀을 때만 최상단으로 스크롤할 수 있도록 구현하였습니다.

## 📌 PR Point
<!-- 리뷰어 분들이 집중적으로 확인해주면 좋을 내용을 적어주세요. -->


## 📌 참고 사항
<!-- 참고할 사항 및 스크린샷, GIF, 동영상이 있다면 적어주세요. -->
