### PR TITLE
[FEAT] 호가정보창 정보들 실제 데이터 적용 (#67)

### DIFF
--- a/FakeBithumbAssignment/FakeBithumbAssignment/Screens/Coin/Tabs/CoinQuoteInformationTab/CoinQuoteInformationTabViewController.swift
+++ b/FakeBithumbAssignment/FakeBithumbAssignment/Screens/Coin/Tabs/CoinQuoteInformationTab/CoinQuoteInformationTabViewController.swift
@@ -113,16 +113,34 @@ class CoinQuoteInformationTabViewController: BaseViewController {
         self.scrollView.snp.makeConstraints { make in
             make.leading.top.trailing.bottom.equalTo(self.view.safeAreaLayoutGuide)
         }
+        let firstInformationStackView: UIStackView = UIStackView(
+            arrangedSubviews: [UIView(), self.coinFirstInformationView]
+        ).then {
+            $0.axis = .vertical
+            $0.alignment = .fill
+        }
+        self.coinFirstInformationView.snp.makeConstraints { make in
+            make.height.equalTo(130)
+        }
         let upperStackView = UIStackView(arrangedSubviews: [
-            self.askTableView, self.coinFirstInformationView
+            self.askTableView, firstInformationStackView
         ]).then {
             $0.axis = .horizontal
         }
         self.coinFirstInformationView.snp.makeConstraints { make in
             make.width.equalTo(upperStackView).multipliedBy(1.0/3.0)
         }
+        let secondInformationStackView: UIStackView = UIStackView(
+            arrangedSubviews: [self.coinSecondInformationView, UIView()]
+        ).then {
+            $0.axis = .vertical
+            $0.alignment = .fill
+        }
+        self.coinSecondInformationView.snp.makeConstraints { make in
+            make.height.equalTo(130)
+        }
         let lowerStackView = UIStackView(arrangedSubviews: [
-            self.coinSecondInformationView, self.bidTableView,
+            secondInformationStackView, self.bidTableView,
         ]).then {
             $0.axis = .horizontal
         }
@@ -212,6 +230,8 @@ class CoinQuoteInformationTabViewController: BaseViewController {
             tickTypes: [.mid]
         ) { ticker in
             self.prevClosePrice = ticker.content.prevClosePrice
+            self.coinFirstInformationView.ticker = ticker
+            self.coinSecondInformationView.ticker = ticker
         }
     }
     

--- a/FakeBithumbAssignment/FakeBithumbAssignment/Screens/Coin/Tabs/CoinQuoteInformationTab/View/CoinFirstInformationView.swift
+++ b/FakeBithumbAssignment/FakeBithumbAssignment/Screens/Coin/Tabs/CoinQuoteInformationTab/View/CoinFirstInformationView.swift
@@ -12,106 +12,78 @@ import Then
 
 final class CoinFirstInformationView: UIView {
     
+    private static let fontSize: CGFloat = 10.0
+    private static let valueFormat: String = "%.1f"
+    
     // MARK: - Instance Property
     
-    private let tradingVolumeTextLabel = UILabel().then {
-        $0.text = "거래량"
-        $0.font = UIFont.preferredFont(forTextStyle: .caption2)
-        $0.textColor = .lightGray
+    var ticker: BTSocketAPIResponse.TickerResponse? = nil {
+        didSet {
+            self.setNeedsLayout()
+        }
     }
-    
-    private let tradingVolumeLabel = UILabel().then {
-        $0.text = "4,974,938 BTC"
-        $0.font = UIFont.preferredFont(forTextStyle: .caption2)
-        $0.textColor = .lightGray
-        $0.textAlignment = .right
-    }
-    
-    private let tradingAmountTextLabel = UILabel().then {
+    private let valueTitleLabel = UILabel().then {
         $0.text = "거래금"
-        $0.font = UIFont.preferredFont(forTextStyle: .caption2)
+        $0.font = UIFont.systemFont(ofSize: CoinFirstInformationView.fontSize)
         $0.textColor = .lightGray
     }
-    
-    private let tradingAmountLabel = UILabel().then {
-        $0.text = "2,280,100 억"
-        $0.font = UIFont.preferredFont(forTextStyle: .caption2)
+    private let valueValueLabel = UILabel().then {
+        $0.font = UIFont.systemFont(ofSize: CoinFirstInformationView.fontSize)
         $0.textColor = .lightGray
         $0.textAlignment = .right
     }
-    
-    private let previousPriceTextLabel = UILabel().then {
-        $0.text = "전일종가"
-        $0.font = UIFont.preferredFont(forTextStyle: .caption2)
+    private let volumeTitleLabel = UILabel().then {
+        $0.text = "거래량"
+        $0.font = UIFont.systemFont(ofSize: CoinFirstInformationView.fontSize)
         $0.textColor = .lightGray
     }
-    
-    private let previousPriceLabel = UILabel().then {
-        $0.text = "47,172,000"
-        $0.font = UIFont.preferredFont(forTextStyle: .caption2)
+    private let volumeValueLabel = UILabel().then {
+        $0.font = UIFont.systemFont(ofSize: CoinFirstInformationView.fontSize)
         $0.textColor = .lightGray
         $0.textAlignment = .right
     }
-    
-    private let startPriceTextLabel = UILabel().then {
-        $0.text = "시가(당일)"
-        $0.font = UIFont.preferredFont(forTextStyle: .caption2)
+    private let openPriceTitleLabel = UILabel().then {
+        $0.text = "시가"
+        $0.font = UIFont.systemFont(ofSize: CoinFirstInformationView.fontSize)
         $0.textColor = .lightGray
     }
-    
-    private let startPriceLabel = UILabel().then {
-        $0.text = "47,171,000"
-        $0.font = UIFont.preferredFont(forTextStyle: .caption2)
+    private let openPriceValueLabel = UILabel().then {
+        $0.font = UIFont.systemFont(ofSize: CoinFirstInformationView.fontSize)
         $0.textColor = .lightGray
         $0.textAlignment = .right
     }
-    
-    private let highPriceTextLabel = UILabel().then {
-        $0.text = "고가(당일)"
-        $0.font = UIFont.preferredFont(forTextStyle: .caption2)
+    private let closePriceTitleLabel = UILabel().then {
+        $0.text = "종가"
+        $0.font = UIFont.systemFont(ofSize: CoinFirstInformationView.fontSize)
         $0.textColor = .lightGray
     }
-    
-    private let highPriceLabel = UILabel().then {
-        $0.text = "47,188,000"
-        $0.font = UIFont.preferredFont(forTextStyle: .caption2)
-        $0.textColor = UIColor(named: "up")
+    private let closePriceValueLabel = UILabel().then {
+        $0.font = UIFont.systemFont(ofSize: CoinFirstInformationView.fontSize)
+        $0.textColor = .lightGray
         $0.textAlignment = .right
     }
-    
-    private let highPriceRateLabel = UILabel().then {
-        $0.text = "1.31%"
-        $0.font = UIFont.preferredFont(forTextStyle: .caption2)
-        $0.textColor = UIColor(named: "up")
-        $0.textAlignment = .left
+    private let lowPriceTitleLabel = UILabel().then {
+        $0.text = "저가"
+        $0.font = UIFont.systemFont(ofSize: CoinFirstInformationView.fontSize)
+        $0.textColor = UIColor(named: "down")
     }
-    
-    private let lowPriceTextLabel = UILabel().then {
-        $0.text = "저가(당일)"
-        $0.font = UIFont.preferredFont(forTextStyle: .caption2)
-        $0.textColor = .lightGray
-    }
-    
-    private let lowPriceLabel = UILabel().then {
-        $0.text = "44,676,000"
-        $0.font = UIFont.preferredFont(forTextStyle: .caption2)
+    private let lowPriceValueLabel = UILabel().then {
+        $0.font = UIFont.systemFont(ofSize: CoinFirstInformationView.fontSize)
         $0.textColor = UIColor(named: "down")
         $0.textAlignment = .right
     }
-    
-    private let lowPriceRateLabel = UILabel().then {
-        $0.text = "-5.29%"
-        $0.font = UIFont.preferredFont(forTextStyle: .caption2)
-        $0.textColor = UIColor(named: "down")
+    private let highPriceTitleLabel = UILabel().then {
+        $0.text = "고가"
+        $0.font = UIFont.systemFont(ofSize: CoinFirstInformationView.fontSize)
+        $0.textColor = UIColor(named: "up")
+    }
+    private let highPriceValueLabel = UILabel().then {
+        $0.font = UIFont.systemFont(ofSize: CoinFirstInformationView.fontSize)
+        $0.textColor = UIColor(named: "up")
         $0.textAlignment = .right
     }
-    
     private let borderView = UIView().then {
         $0.backgroundColor = .lightGray
-    }
-    
-    private let pageControlView = UIView().then {
-        $0.backgroundColor = .red
     }
     
     
@@ -119,131 +91,121 @@ final class CoinFirstInformationView: UIView {
     
     override init(frame: CGRect) {
         super.init(frame: frame)
-        render()
         configUI()
-        
     }
     
-    @available(*, unavailable)
     required init?(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
+        super.init(coder: coder)
     }
     
-    
+    override func layoutSubviews() {
+        guard let ticker = ticker else {
+            return
+        }
+        self.valueValueLabel.text = self.formatToString(of: ticker.content.value)
+        self.volumeValueLabel.text = self.formatToString(of: ticker.content.volume)
+        self.openPriceValueLabel.text = self.formatToString(of: ticker.content.openPrice)
+        self.closePriceValueLabel.text = self.formatToString(of: ticker.content.closePrice)
+        self.highPriceValueLabel.text = self.formatToString(of: ticker.content.highPrice)
+        self.lowPriceValueLabel.text = self.formatToString(of: ticker.content.lowPrice)
+    }
+
     // MARK: - custom funcs
     
-    func render() {
-        self.addSubView(pageControlView)
-        
-        self.pageControlView.snp.makeConstraints { make in
-            make.centerX.equalTo(self)
-            make.width.equalTo(20)
-            make.bottom.equalTo(self)
-        }
-    }
-    
     func configUI() {
-        configStackView()
-    }
-    
-    func configStackView() {
-        let tradingVolumeStackView = UIStackView(arrangedSubviews: [
-            tradingVolumeTextLabel,
-            tradingVolumeLabel
-        ]).then {
+        let valueStackView: UIStackView = UIStackView(
+            arrangedSubviews: [self.valueTitleLabel, self.valueValueLabel]
+        ).then {
             $0.axis = .horizontal
-            $0.spacing = 5
-            $0.distribution = .fill
+            $0.alignment = .center
         }
-        
-        let tradingAmountStackView = UIStackView(arrangedSubviews: [
-            tradingAmountTextLabel,
-            tradingAmountLabel
-        ]).then {
+        self.valueValueLabel.snp.makeConstraints { make in
+            make.width.equalTo(self.valueTitleLabel).multipliedBy(2)
+        }
+        let volumeStackView: UIStackView = UIStackView(
+            arrangedSubviews: [self.volumeTitleLabel, self.volumeValueLabel]
+        ).then {
             $0.axis = .horizontal
-            $0.spacing = 5
-            $0.distribution = .fill
+            $0.alignment = .center
         }
-        
-        let previousPriceStackView = UIStackView(arrangedSubviews: [
-            previousPriceTextLabel,
-            previousPriceLabel
-        ]).then {
+        self.volumeValueLabel.snp.makeConstraints { make in
+            make.width.equalTo(self.volumeTitleLabel).multipliedBy(2)
+        }
+        let openPriceStackView: UIStackView = UIStackView(
+            arrangedSubviews: [self.openPriceTitleLabel, self.openPriceValueLabel]
+        ).then {
             $0.axis = .horizontal
-            $0.spacing = 5
-            $0.distribution = .fill
+            $0.alignment = .center
         }
-        
-        let startPriceStackView = UIStackView(arrangedSubviews: [
-            startPriceTextLabel,
-            startPriceLabel
-        ]).then {
+        self.openPriceValueLabel.snp.makeConstraints { make in
+            make.width.equalTo(self.openPriceTitleLabel).multipliedBy(2)
+        }
+        let closePriceStackView: UIStackView = UIStackView(
+            arrangedSubviews: [self.closePriceTitleLabel, self.closePriceValueLabel]
+        ).then {
             $0.axis = .horizontal
-            $0.spacing = 5
-            $0.distribution = .fill
+            $0.alignment = .center
         }
-        
-        let highPriceStackView = UIStackView(arrangedSubviews: [
-            highPriceTextLabel,
-            highPriceLabel
-        ]).then {
+        self.closePriceValueLabel.snp.makeConstraints { make in
+            make.width.equalTo(self.closePriceTitleLabel).multipliedBy(2)
+        }
+        let highPriceStackView: UIStackView = UIStackView(
+            arrangedSubviews: [self.highPriceTitleLabel, self.highPriceValueLabel]
+        ).then {
             $0.axis = .horizontal
-            $0.spacing = 5
-            $0.distribution = .fill
+            $0.alignment = .center
         }
-        
-        let highPriceRateStackView = UIStackView(arrangedSubviews: [
-            UIView(),
-            highPriceRateLabel
-        ]).then {
+        self.highPriceValueLabel.snp.makeConstraints { make in
+            make.width.equalTo(self.highPriceTitleLabel).multipliedBy(2)
+        }
+        let lowPriceStackView: UIStackView = UIStackView(
+            arrangedSubviews: [self.lowPriceTitleLabel, self.lowPriceValueLabel]
+        ).then {
             $0.axis = .horizontal
-            $0.spacing = 5
-            $0.distribution = .fill
+            $0.alignment = .center
         }
-        
-        let lowPriceStackView = UIStackView(arrangedSubviews: [
-            lowPriceTextLabel,
-            lowPriceLabel
-        ]).then {
-            $0.axis = .horizontal
-            $0.spacing = 5
-            $0.distribution = .fill
+        self.lowPriceValueLabel.snp.makeConstraints { make in
+            make.width.equalTo(self.lowPriceTitleLabel).multipliedBy(2)
         }
-        
-        let lowPriceRateStackView = UIStackView(arrangedSubviews: [
-            UIView(),
-            lowPriceRateLabel
-        ]).then {
-            $0.axis = .horizontal
-            $0.spacing = 5
-            $0.distribution = .fill
-        }
-        
-        let wholeStackView = UIStackView(arrangedSubviews: [
-            tradingVolumeStackView,
-            tradingAmountStackView,
-            self.borderView,
-            previousPriceStackView,
-            startPriceStackView,
-            highPriceStackView,
-            highPriceRateStackView,
-            lowPriceStackView,
-            lowPriceRateStackView
-        ]).then {
+        let wholeStackView: UIStackView = UIStackView(
+            arrangedSubviews: [
+                valueStackView,
+                volumeStackView,
+                self.borderView,
+                openPriceStackView,
+                highPriceStackView,
+                lowPriceStackView,
+                closePriceStackView
+            ]
+        ).then {
             $0.axis = .vertical
-            $0.spacing = 5
-            $0.distribution = .fill
+            $0.distribution = .equalSpacing
+            $0.alignment = .fill
         }
-        
-        self.addSubview(wholeStackView)
-        wholeStackView.snp.makeConstraints { make in
-            make.leading.equalTo(self).offset(2)
-            make.trailing.equalTo(self).inset(2)
-            make.bottom.equalTo(self.pageControlView).inset(5)
-        }
-        
         self.borderView.snp.makeConstraints { make in
             make.height.equalTo(0.3)
+        }
+        self.addSubview(wholeStackView)
+        wholeStackView.snp.makeConstraints { make in
+            make.edges.equalToSuperview().inset(
+                UIEdgeInsets(
+                    top: 5,
+                    left: 5,
+                    bottom: 5,
+                    right: 5
+                )
+            )
+        }
+    }
+    
+    private func formatToString(of number: Double) -> String {
+        if number > 100000000.0 {
+            return String(
+                format: CoinFirstInformationView.valueFormat,
+                number / 100000000.0
+            ) + "억"
+        } else {
+            return String(format: CoinFirstInformationView.valueFormat, number)
         }
     }
 }

--- a/FakeBithumbAssignment/FakeBithumbAssignment/Screens/Coin/Tabs/CoinQuoteInformationTab/View/CoinSecondInformationView.swift
+++ b/FakeBithumbAssignment/FakeBithumbAssignment/Screens/Coin/Tabs/CoinQuoteInformationTab/View/CoinSecondInformationView.swift
@@ -12,80 +12,78 @@ import Then
 
 final class CoinSecondInformationView: UIView {
     
+    private static let fontSize: CGFloat = 10.0
+    private static let valueFormat: String = "%.1f"
+    
     // MARK: - Instance Property
     
-    private let previousTradingVolumeTextLabel = UILabel().then {
-        $0.text = "전일거래량"
-        $0.font = UIFont.preferredFont(forTextStyle: .caption2)
+    var ticker: BTSocketAPIResponse.TickerResponse? = nil {
+        didSet {
+            self.setNeedsLayout()
+        }
+    }
+    private let sellVolumeTitleLabel = UILabel().then {
+        $0.text = "매도누적"
+        $0.font = UIFont.systemFont(ofSize: CoinSecondInformationView.fontSize)
         $0.textColor = .lightGray
     }
-    
-    private let previousTradingVolumeLabel = UILabel().then {
-        $0.text = "5,562,495BTC"
-        $0.font = UIFont.preferredFont(forTextStyle: .caption2)
-        $0.textColor = .lightGray
-        $0.textAlignment = .right
-    }
-    
-    private let previousTradingAmountTextLabel = UILabel().then {
-        $0.text = "전일거래금"
-        $0.font = UIFont.preferredFont(forTextStyle: .caption2)
-        $0.textColor = .lightGray
-    }
-    
-    private let previousTradingAmountLabel = UILabel().then {
-        $0.text = "2,280,100KRW"
-        $0.font = UIFont.preferredFont(forTextStyle: .caption2)
+    private let sellVolumeValueLabel = UILabel().then {
+        $0.font = UIFont.systemFont(ofSize: CoinSecondInformationView.fontSize)
         $0.textColor = .lightGray
         $0.textAlignment = .right
     }
-    
-    private let highPriceTextLabel = UILabel().then {
-        $0.text = "고가(52주)"
-        $0.font = UIFont.preferredFont(forTextStyle: .caption2)
+    private let buyVolumeTitleLabel = UILabel().then {
+        $0.text = "매수누적"
+        $0.font = UIFont.systemFont(ofSize: CoinSecondInformationView.fontSize)
         $0.textColor = .lightGray
     }
-    
-    private let highPriceLabel = UILabel().then {
-        $0.text = "82,477,000"
-        $0.font = UIFont.preferredFont(forTextStyle: .caption2)
-        $0.textColor = .black
-        $0.textAlignment = .right
-    }
-    
-    private let highPriceDateLabel = UILabel().then {
-        $0.text = "2021-11-09"
-        $0.font = UIFont.preferredFont(forTextStyle: .caption2)
-        $0.textColor = .lightGray
-        $0.textAlignment = .left
-    }
-    
-    private let lowPriceTextLabel = UILabel().then {
-        $0.text = "저가(52주)"
-        $0.font = UIFont.preferredFont(forTextStyle: .caption2)
-        $0.textColor = .lightGray
-    }
-    
-    private let lowPriceLabel = UILabel().then {
-        $0.text = "33,700,000"
-        $0.font = UIFont.preferredFont(forTextStyle: .caption2)
-        $0.textColor = .black
-        $0.textAlignment = .right
-    }
-    
-    private let lowPriceDateLabel = UILabel().then {
-        $0.text = "2021-06-22"
-        $0.font = UIFont.preferredFont(forTextStyle: .caption2)
+    private let buyVolumeValueLabel = UILabel().then {
+        $0.font = UIFont.systemFont(ofSize: CoinSecondInformationView.fontSize)
         $0.textColor = .lightGray
         $0.textAlignment = .right
     }
-    
+    private let prevClosePriceTitleLabel = UILabel().then {
+        $0.text = "전일종가"
+        $0.font = UIFont.systemFont(ofSize: CoinSecondInformationView.fontSize)
+        $0.textColor = .lightGray
+    }
+    private let prevClosePriceValueLabel = UILabel().then {
+        $0.font = UIFont.systemFont(ofSize: CoinSecondInformationView.fontSize)
+        $0.textColor = .lightGray
+        $0.textAlignment = .right
+    }
+    private let chgRateTitleLabel = UILabel().then {
+        $0.text = "변동률"
+        $0.font = UIFont.systemFont(ofSize: CoinSecondInformationView.fontSize)
+        $0.textColor = .lightGray
+    }
+    private let chgRateValueLabel = UILabel().then {
+        $0.font = UIFont.systemFont(ofSize: CoinSecondInformationView.fontSize)
+        $0.textColor = .lightGray
+        $0.textAlignment = .right
+    }
+    private let chgAmtTitleLabel = UILabel().then {
+        $0.text = "변동액"
+        $0.font = UIFont.systemFont(ofSize: CoinSecondInformationView.fontSize)
+        $0.textColor = .lightGray
+    }
+    private let chgAmtValueLabel = UILabel().then {
+        $0.font = UIFont.systemFont(ofSize: CoinSecondInformationView.fontSize)
+        $0.textColor = .lightGray
+        $0.textAlignment = .right
+    }
+    private let volumePowerTitleLabel = UILabel().then {
+        $0.text = "체결강도"
+        $0.font = UIFont.systemFont(ofSize: CoinSecondInformationView.fontSize)
+        $0.textColor = .lightGray
+    }
+    private let volumePowerValueLabel = UILabel().then {
+        $0.font = UIFont.systemFont(ofSize: CoinSecondInformationView.fontSize)
+        $0.textColor = .lightGray
+        $0.textAlignment = .right
+    }
     private let borderView = UIView().then {
         $0.backgroundColor = .lightGray
-    }
-    
-    private let pageControlView = UIView().then {
-        $0.backgroundColor = .red
     }
     
     
@@ -93,111 +91,123 @@ final class CoinSecondInformationView: UIView {
     
     override init(frame: CGRect) {
         super.init(frame: frame)
-        render()
         configUI()
-        
     }
     
-    @available(*, unavailable)
     required init?(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
+        super.init(coder: coder)
     }
     
+    override func layoutSubviews() {
+        guard let ticker = ticker else {
+            return
+        }
+        self.sellVolumeValueLabel.text = self.formatToString(of: ticker.content.sellVolume)
+        self.buyVolumeValueLabel.text = self.formatToString(of: ticker.content.buyVolume)
+        self.prevClosePriceValueLabel.text = self.formatToString(
+            of: ticker.content.prevClosePrice
+        )
+        self.chgRateValueLabel.text = self.formatToString(of: ticker.content.chgRate)
+        self.volumePowerValueLabel.text = self.formatToString(of: ticker.content.volumePower)
+        self.chgAmtValueLabel.text = self.formatToString(of: ticker.content.chgAmt)
+    }
     
     // MARK: - custom funcs
-    
-    func render() {
-        self.addSubView(pageControlView)
-        
-        self.pageControlView.snp.makeConstraints { make in
-            make.centerX.equalTo(self)
-            make.width.equalTo(20)
-            make.bottom.equalTo(self)
-        }
-    }
-    
+
     func configUI() {
-        configStackView()
-    }
-    
-    func configStackView() {
-        let tradingVolumeStackView = UIStackView(arrangedSubviews: [
-            previousTradingVolumeTextLabel,
-            previousTradingVolumeLabel
-        ]).then {
+        let sellVolumeStackView: UIStackView = UIStackView(
+            arrangedSubviews: [self.sellVolumeTitleLabel, self.sellVolumeValueLabel]
+        ).then {
             $0.axis = .horizontal
-            $0.spacing = 5
-            $0.distribution = .fill
+            $0.alignment = .center
         }
-        
-        let tradingAmountStackView = UIStackView(arrangedSubviews: [
-            previousTradingAmountTextLabel,
-            previousTradingAmountLabel
-        ]).then {
+        self.sellVolumeValueLabel.snp.makeConstraints { make in
+            make.width.equalTo(self.sellVolumeTitleLabel).multipliedBy(2)
+        }
+        let buyVolumeStackView: UIStackView = UIStackView(
+            arrangedSubviews: [self.buyVolumeTitleLabel, self.buyVolumeValueLabel]
+        ).then {
             $0.axis = .horizontal
-            $0.spacing = 5
-            $0.distribution = .fill
+            $0.alignment = .center
         }
-        
-        let highPriceStackView = UIStackView(arrangedSubviews: [
-            highPriceTextLabel,
-            highPriceLabel
-        ]).then {
+        self.buyVolumeValueLabel.snp.makeConstraints { make in
+            make.width.equalTo(self.buyVolumeTitleLabel).multipliedBy(2)
+        }
+        let prevClosePriceStackView: UIStackView = UIStackView(
+            arrangedSubviews: [self.prevClosePriceTitleLabel, self.prevClosePriceValueLabel]
+        ).then {
             $0.axis = .horizontal
-            $0.spacing = 5
-            $0.distribution = .fill
+            $0.alignment = .center
         }
-        
-        let highPriceRateStackView = UIStackView(arrangedSubviews: [
-            UIView(),
-            highPriceDateLabel
-        ]).then {
+        self.prevClosePriceValueLabel.snp.makeConstraints { make in
+            make.width.equalTo(self.prevClosePriceTitleLabel).multipliedBy(2)
+        }
+        let chgRateStackView: UIStackView = UIStackView(
+            arrangedSubviews: [self.chgRateTitleLabel, self.chgRateValueLabel]
+        ).then {
             $0.axis = .horizontal
-            $0.spacing = 5
-            $0.distribution = .fill
+            $0.alignment = .center
         }
-        
-        let lowPriceStackView = UIStackView(arrangedSubviews: [
-            lowPriceTextLabel,
-            lowPriceLabel
-        ]).then {
+        self.chgRateValueLabel.snp.makeConstraints { make in
+            make.width.equalTo(self.chgRateTitleLabel).multipliedBy(2)
+        }
+        let volumePowerStackView: UIStackView = UIStackView(
+            arrangedSubviews: [self.volumePowerTitleLabel, self.volumePowerValueLabel]
+        ).then {
             $0.axis = .horizontal
-            $0.spacing = 5
-            $0.distribution = .fill
+            $0.alignment = .center
         }
-        
-        let lowPriceRateStackView = UIStackView(arrangedSubviews: [
-            UIView(),
-            lowPriceDateLabel
-        ]).then {
+        self.volumePowerValueLabel.snp.makeConstraints { make in
+            make.width.equalTo(self.volumePowerTitleLabel).multipliedBy(2)
+        }
+        let chgAmtStackView: UIStackView = UIStackView(
+            arrangedSubviews: [self.chgAmtTitleLabel, self.chgAmtValueLabel]
+        ).then {
             $0.axis = .horizontal
-            $0.spacing = 5
-            $0.distribution = .fill
+            $0.alignment = .center
         }
-        
-        let wholeStackView = UIStackView(arrangedSubviews: [
-            tradingVolumeStackView,
-            tradingAmountStackView,
-            self.borderView,
-            highPriceStackView,
-            highPriceRateStackView,
-            lowPriceStackView,
-            lowPriceRateStackView
-        ]).then {
+        self.chgAmtValueLabel.snp.makeConstraints { make in
+            make.width.equalTo(self.chgAmtTitleLabel).multipliedBy(2)
+        }
+        let wholeStackView: UIStackView = UIStackView(
+            arrangedSubviews: [
+                sellVolumeStackView,
+                buyVolumeStackView,
+                self.borderView,
+                prevClosePriceStackView,
+                volumePowerStackView,
+                chgAmtStackView,
+                chgRateStackView
+            ]
+        ).then {
             $0.axis = .vertical
-            $0.spacing = 5
-            $0.distribution = .fill
+            $0.distribution = .equalSpacing
+            $0.alignment = .fill
         }
-        
-        self.addSubview(wholeStackView)
-        wholeStackView.snp.makeConstraints { make in
-            make.leading.equalTo(self).offset(2)
-            make.trailing.equalTo(self).inset(2)
-            make.top.equalTo(self.snp.top).offset(5)
-        }
-        
         self.borderView.snp.makeConstraints { make in
             make.height.equalTo(0.3)
+        }
+        self.addSubview(wholeStackView)
+        wholeStackView.snp.makeConstraints { make in
+            make.edges.equalToSuperview().inset(
+                UIEdgeInsets(
+                    top: 5,
+                    left: 5,
+                    bottom: 5,
+                    right: 5
+                )
+            )
+        }
+    }
+    
+    private func formatToString(of number: Double) -> String {
+        if number > 100000000.0 {
+            return String(
+                format: CoinSecondInformationView.valueFormat,
+                number / 100000000.0
+            ) + "억"
+        } else {
+            return String(format: CoinSecondInformationView.valueFormat, number)
         }
     }
 }


### PR DESCRIPTION
## 📌 관련 이슈
 closed #67

## 📌 구현 및 변경 사항
- 호가정보창에 오른쪽, 왼쪽 중앙쪽에 존재하는 현재 코인 정보들 실제 데이터로 표시되도록 수정 했습니다
- 정보는 ticker api의 mid 로 받아와지는 정보들을 넣어 주었습니다

## 📌 PR Point


## 📌 참고 사항
![Simulator Screen Shot - iPhone 13 Pro - 2022-03-11 at 04 56 57](https://user-images.githubusercontent.com/94916868/157744508-656285ba-93af-427d-8866-8bc69ef1134b.png)
