### PR TITLE
[FEAT] : 가격 변동 시 박스 색상 적용, 검색 중 화면 터치하여 키보드 내림 구현 (#89)

### DIFF
--- a/FakeBithumbAssignment/FakeBithumbAssignment/Screens/Main/Model/CoinData.swift
+++ b/FakeBithumbAssignment/FakeBithumbAssignment/Screens/Main/Model/CoinData.swift
@@ -15,7 +15,7 @@ final class CoinData {
     var isInterested: Bool
     var popularity: Int
     var changeAmount: String
-
+    var previousPrice: String
     // MARK: - Initializer
 
     init(
@@ -25,7 +25,8 @@ final class CoinData {
         tradeValue: String,
         isInterested: Bool = false,
         popularity: Int,
-        changeAmount: String
+        changeAmount: String,
+        previousPrice: String
     ) {
         self.coinName = coinName
         self.currentPrice = currentPrice
@@ -34,6 +35,7 @@ final class CoinData {
         self.isInterested = isInterested
         self.popularity = popularity
         self.changeAmount = changeAmount
+        self.previousPrice = previousPrice
     }
 }
 

--- a/FakeBithumbAssignment/FakeBithumbAssignment/Screens/Main/View/CoinTableViewCell.swift
+++ b/FakeBithumbAssignment/FakeBithumbAssignment/Screens/Main/View/CoinTableViewCell.swift
@@ -79,9 +79,9 @@ class CoinTableViewCell: BaseTableViewCell {
         guard let model = model else {
             return
         }
-        
-        self.checkChangeRate(of: model)
 
+        self.checkChangePrice(of: model)
+        
         self.coinName.text = model.coinName.rawValue
         self.coinSymbol.text = "\(model.coinName)/KRW"
         self.currentPrice.text = model.currentPrice
@@ -93,6 +93,20 @@ class CoinTableViewCell: BaseTableViewCell {
 
         if let changeRate = Double(changeRateString) {
             self.configureTextColor(changeRate)
+        }
+    }
+
+    private func checkChangePrice(of model: CoinData) {
+        let previousPriceString = model.previousPrice.replacingOccurrences(of: ",", with: "")
+        let currentPriceString = model.currentPrice.replacingOccurrences(of: ",", with: "")
+        
+        guard let previousPrice = Double(previousPriceString),
+              let currentPrice = Double(currentPriceString) else {
+                  return
+              }
+        
+        if previousPrice != currentPrice {
+            self.priceIncrement = previousPrice < currentPrice ? true : false
             guard let color = priceIncrement ? UIColor(named: "up") : UIColor(named: "down")
             else {
                 return
@@ -100,21 +114,6 @@ class CoinTableViewCell: BaseTableViewCell {
 
             self.currentPrice.animateBorderColor(toColor: color, duration: 0.1)
         }
-    }
-
-    private func checkChangeRate(of model: CoinData) {
-        guard var previousChangeRateString = self.changeRate.text else {
-            return
-        }
-        
-        previousChangeRateString.removeLast()
-        
-        guard let previousChangeRate = Double(previousChangeRateString),
-              let updatedChangeRate = Double(model.changeRate) else {
-                  return
-              }
-
-        self.priceIncrement = previousChangeRate < updatedChangeRate ? true : false
     }
 
     private func configureTextColor(_ changeRate: Double) {


### PR DESCRIPTION
## 📌 관련 이슈
<!-- close할 이슈 번호(#000)를 적어주세요. (ex. closed #16) -->
closed #89 

## 📌 구현 및 변경 사항
<!-- 구현 및 변경한 내용과 그 이유를 적어주세요. -->
가격 변동시 박스의 색상이 이상하던 것을 픽스하였습니다.
코인데이터 클래스에 해당 코인의 이전 가격 프로퍼티를 생성하여 이전 가격과 현재 가격을 비교하여 구현할 수 있었습니다.
검색 도중 테이블 뷰를 터치했을 때, 해당 코인으로 푸시됐었는데,  검색창이 isActive이 됐을 때만 검색창을 내리고, 아닐 경우 해당 셀로 푸쉬하는 방향으로 구현하였습니다.

## 📌 PR Point
<!-- 리뷰어 분들이 집중적으로 확인해주면 좋을 내용을 적어주세요. -->


## 📌 참고 사항
<!-- 참고할 사항 및 스크린샷, GIF, 동영상이 있다면 적어주세요. -->
